### PR TITLE
Enable external streaming webcam URL as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DESCRIPTION
 
-Point your laptop web cam at a piece of paper
-and the program will stretch the writable area
+Point your laptop web cam (or any streaming webcam) at a piece of paper
+(or an actual whiteboard) and the program will stretch the writable area
 over the whole screen.
 
 ![](demo.gif)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ over the whole screen.
 
 - python 3
 - opencv (with the `aruco` module), numpy
+- to use a streaming webcam URL as the camera source (see help for example), opencv must be compiled with ffmpeg or gstreamer support
+
 
 # USAGE
 

--- a/cam_board
+++ b/cam_board
@@ -10,8 +10,20 @@ if(__name__ == "__main__"):
 
     # parsing command line arguments {
 
-    parser = argparse.ArgumentParser(description = "Filter web cam image to look like a white/black board.")
+#    parser = argparse.ArgumentParser(description = "Filter web cam image to look like a white/black board.")
+
+    from argparse import RawTextHelpFormatter
+    parser = argparse.ArgumentParser(description = '''
+ Filter web cam image to look like a white/black board.
+ Keyboard shortcuts are described below. Additional shortcuts:
+ a (use average of recent frames to smooth out the motions in the video),
+ p (pause),
+ s (save frame, see --path),
+ q (quit).
+ ''', formatter_class=RawTextHelpFormatter)
+
     parser.add_argument("--invert" , "-i" , action = "store_true" , help = "Invert colors.")
+    parser.add_argument("--raruco" , "-r" , action = "store_true" , help = "Warp inside aruco markers to remove them (keyboard shortcut r).")
     parser.add_argument("--denoise" , "-d" , action = "store_true" , help = "Denoise.")
     parser.add_argument("--ldenoise" , "-l" , action = "store_true" , help = "Denoise with color.")
     parser.add_argument("--fullscreen" , "-f" , action = "store_true" , help = "Full screen.")
@@ -19,6 +31,7 @@ if(__name__ == "__main__"):
     parser.add_argument("--kernel" , "-k" , action = "store_true" , help = "Apply sharpening kernel to image.")
     parser.add_argument("--camera" , "-c" , help = "Provide integer to change the v4l2 camera device number, by default this value is 0. Alternatively provide a fully qualified streaming webcam URL, e.g. http://<somecamera>/video/mjpeg")
     parser.add_argument("--path" , "-p" , help = "Path to directory where frames will be saved. By default this is the current directory.")
+    parser.add_argument("--aspectratio" , "-a" , help = "Resolution of the camera eg 1280x720, carefull not all resolutions are supported.")
     args = parser.parse_args() 
 
     save_dir = os.getcwd()
@@ -37,9 +50,9 @@ if(__name__ == "__main__"):
 
     config = configparser.ConfigParser()
     config.read(os.path.join(script_path , "aruco_cam_config"))
-   
+
     buff = int(config["perspectiveMatrix"]["buffer"])
-    
+
     levels = []
     for c in config["levels"]:
         levels.append(list(map(lambda x : float(x) , config["levels"][c].strip().split())))
@@ -64,17 +77,27 @@ if(__name__ == "__main__"):
     cap = cv2.VideoCapture(args.camera)
     if(not cap.isOpened()):
         print ('Failed to open camera [',args.camera,']')
+    if(args.aspectratio != None):
+        res = list(map(lambda x : int(x) , args.aspectratio.split("x")))
+        cap.set(cv2.CAP_PROP_FRAME_WIDTH, res[0])
+        cap.set(cv2.CAP_PROP_FRAME_HEIGHT, res[1])
     # } getting camera
 
     # window for cv {
     cv2.namedWindow('frame' , cv2.WINDOW_GUI_NORMAL)
+    cv2.resizeWindow('frame', 718, 478)
     if(args.fullscreen):
         cv2.setWindowProperty('frame' , cv2.WND_PROP_FULLSCREEN , cv2.WINDOW_FULLSCREEN)
     # } window for cv
 
     # global {
 
-    # for denoising 
+    # for freazing
+    freeze = False
+    ret = None
+    frame = None
+
+    # for denoising
     ones = None
     black = None
     white = None
@@ -88,10 +111,10 @@ if(__name__ == "__main__"):
     frame_buff = []
     avg = False
 
-    # points surrounfing the QR code available
+    # points surrounding the QR code available
     got_points = False
 
-    # points surrounfing the QR code
+    # points surrounding the QR code
     pointsglob = None
 
     # aruco markers
@@ -103,14 +126,15 @@ if(__name__ == "__main__"):
     # main loop {
 
     try:
-    
+
         while(True):
-            # Capture frame-by-frame
-            ret, frame = cap.read()
+            if(not freeze):
+                # Capture frame-by-frame
+                ret, frame = cap.read()
 
             gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
             corners, ids, rejectedImgPoints = cv2.aruco.detectMarkers(gray, aruco_dict, parameters=parameters)
-            
+
             if(len(corners) == 4):
                 allids = [0 , 1 , 2 , 3]
                 pts = [None , None , None , None]
@@ -124,7 +148,7 @@ if(__name__ == "__main__"):
                                 ];
 
                 ok = not None in pts
-            
+
                 if(ok):
                     ones = numpy.ones(frame.shape[:2] , numpy.uint8)
                     black = 0 * ones
@@ -136,7 +160,10 @@ if(__name__ == "__main__"):
 
             if(got_points and (not args.warp)):
 
-                src = numpy.array([pointsglob[0][0] , pointsglob[1][1] , pointsglob[3][2] , pointsglob[2][3]] , numpy.float32)
+                if(not args.raruco):
+                    src = numpy.array([pointsglob[0][0] , pointsglob[1][1] , pointsglob[3][2] , pointsglob[2][3]] , numpy.float32)
+                else:
+                    src = numpy.array([pointsglob[0][2] , pointsglob[1][3] , pointsglob[3][0] , pointsglob[2][1]] , numpy.float32)
                 dst = numpy.array([[frame.shape[1] , frame.shape[0]] , [0.0 , frame.shape[0]] , [0.0 , 0.0] , [frame.shape[1] , 0.0]] , numpy.float32)
                 m = cv2.getPerspectiveTransform(src , dst)
                 m_list.append(m)
@@ -167,7 +194,7 @@ if(__name__ == "__main__"):
                 gray[: , gray.shape[1] - 3 : gray.shape[1]] = 0.0
 
                 blured_gray = cv2.filter2D(gray , -1 , blur_kernel)
-                
+
                 stdv = numpy.sqrt(numpy.mean(((gray - blured_gray) * (gray - blured_gray)).flatten()))
 
                 if(not args.ldenoise):
@@ -182,16 +209,16 @@ if(__name__ == "__main__"):
                     h_res = hls[: , : , 0]
                     l_res = white.astype("float32")
                     s_res = hls[: , : , 2]
-                    
+
                     l = levels[0]
-                    
+
                     l_res = numpy.where((gray - blured_gray) > l_col * stdv , hls[: , : , 1] , l_res)
 
                     b_res = white.astype("float32")
-                    
+
                     warped = cv2.cvtColor(cv2.merge((h_res.astype("uint8") , l_res.astype("uint8") , s_res.astype("uint8"))) , cv2.COLOR_HLS2BGR)
 
-            
+
             if(args.kernel):
                 kernel = numpy.array(
                             [
@@ -211,7 +238,7 @@ if(__name__ == "__main__"):
                 frame_buff.append(warped)
                 if(len(frame_buff) > f_buff):
                     frame_buff.pop(0)
-               
+
                 smooth = numpy.zeros(warped.shape , numpy.float32)
 
                 for f in frame_buff:
@@ -226,7 +253,7 @@ if(__name__ == "__main__"):
             cv2.imshow('frame',warped)
 
             key = cv2.waitKey(1)
- 
+
             if(key == ord('q')):
                 break
             elif(key == ord('s')):
@@ -245,10 +272,14 @@ if(__name__ == "__main__"):
                 args.denoise = not args.denoise
             elif(key == ord('l')):
                 args.ldenoise = not args.ldenoise
+            elif(key == ord('r')):
+                args.raruco = not args.raruco
             elif(key == ord('w')):
                 args.warp = not args.warp
             elif(key == ord('k')):
                 args.kernel = not args.kernel
+            elif(key == ord('p')):
+                freeze = not freeze
             elif(key == ord('f')):
                 args.fullscreen = not args.fullscreen
                 if(args.fullscreen):

--- a/cam_board
+++ b/cam_board
@@ -107,7 +107,6 @@ if(__name__ == "__main__"):
         while(True):
             # Capture frame-by-frame
             ret, frame = cap.read()
-#            frame = cv2.imread('/tmp/clipped_wb.png',1)
 
             gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
             corners, ids, rejectedImgPoints = cv2.aruco.detectMarkers(gray, aruco_dict, parameters=parameters)

--- a/cam_board
+++ b/cam_board
@@ -17,7 +17,7 @@ if(__name__ == "__main__"):
     parser.add_argument("--fullscreen" , "-f" , action = "store_true" , help = "Full screen.")
     parser.add_argument("--warp" , "-w" , action = "store_true" , help = "Don't warp image to writable area.")
     parser.add_argument("--kernel" , "-k" , action = "store_true" , help = "Apply sharpening kernel to image.")
-    parser.add_argument("--camera" , "-c" , help = "Provide integer to change the camera number, by default this value is 0.")
+    parser.add_argument("--camera" , "-c" , help = "Provide integer to change the v4l2 camera device number, by default this value is 0. Alternatively provide a fully qualified streaming webcam URL, e.g. http://<somecamera>/video/mjpeg")
     parser.add_argument("--path" , "-p" , help = "Path to directory where frames will be saved. By default this is the current directory.")
     args = parser.parse_args() 
 
@@ -56,10 +56,15 @@ if(__name__ == "__main__"):
     if(args.camera == None):
         # by default uses the first camera
         args.camera = 0
-    else:
-        args.camera = int(args.camera)
+    try:
+        if(not args.camera.startswith('http')):
+            args.camera = int(args.camera)
+    except TypeError as te:
+        print('Invalid --camera argument [',args.camera,']')
     cap = cv2.VideoCapture(args.camera)
-    # } getting camera 
+    if(not cap.isOpened()):
+        print ('Failed to open camera [',args.camera,']')
+    # } getting camera
 
     # window for cv {
     cv2.namedWindow('frame' , cv2.WINDOW_GUI_NORMAL)
@@ -102,6 +107,7 @@ if(__name__ == "__main__"):
         while(True):
             # Capture frame-by-frame
             ret, frame = cap.read()
+#            frame = cv2.imread('/tmp/clipped_wb.png',1)
 
             gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
             corners, ids, rejectedImgPoints = cv2.aruco.detectMarkers(gray, aruco_dict, parameters=parameters)


### PR DESCRIPTION
This allows for streaming inputs like

`$ cam_board --camera http://<some_camera>/video/mjpeg`

opencv must be compiled with ffmpeg or gstreamer support (or both will work too, as ffmpeg takes priority).